### PR TITLE
Search for the library containing: tigetnum (tinfo)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -113,6 +113,7 @@ AC_CHECK_FUNCS([geteuid getpwuid fmemopen strsep])
 AC_SEARCH_LIBS([endwin],[curses ncurses])
 AC_SEARCH_LIBS([readline],[readline])
 AC_SEARCH_LIBS([add_history],[readline history])
+AC_SEARCH_LIBS([tigetnum],[curses ncurses tinfo])
 
 # If readline wasn't disabled by the user, does it actually exist and is it a
 # proper readline?


### PR DESCRIPTION
For me, `tigetnum` is found in tinfo.so, ncurses has been split off into
tinfo due to being compiled with the --with-termlib flag.

pkg-config --libs automatically reports this, but this check is good
enough to catch this specific problem.