### PR TITLE
build: resolve compile failure due to improper attribute syntax

### DIFF
--- a/src/c_ast.h
+++ b/src/c_ast.h
@@ -496,7 +496,7 @@ void c_ast_free( c_ast_t *ast );
  * @sa c_ast_is_parent()
  * @sa c_ast_is_referrer()
  */
-C_AST_H_INLINE NODISCARD
+NODISCARD C_AST_H_INLINE
 bool c_ast_is_orphan( c_ast_t const *ast ) {
   return ast->parent_ast == NULL || ast->parent_ast->as.parent.of_ast != ast;
 }
@@ -510,7 +510,7 @@ bool c_ast_is_orphan( c_ast_t const *ast ) {
  * @sa c_ast_is_orphan()
  * @sa c_ast_is_referrer()
  */
-C_AST_H_INLINE NODISCARD
+NODISCARD C_AST_H_INLINE
 bool c_ast_is_parent( c_ast_t const *ast ) {
   return ast != NULL && (ast->kind & K_ANY_PARENT) != 0;
 }
@@ -524,7 +524,7 @@ bool c_ast_is_parent( c_ast_t const *ast ) {
  * @sa c_ast_is_orphan()
  * @sa c_ast_is_parent()
  */
-C_AST_H_INLINE NODISCARD
+NODISCARD C_AST_H_INLINE
 bool c_ast_is_referrer( c_ast_t const *ast ) {
   return ast != NULL && (ast->kind & K_ANY_REFERRER) != 0;
 }
@@ -566,7 +566,7 @@ c_ast_t* c_ast_new( c_ast_kind_t kind, unsigned depth, c_loc_t const *loc,
  * @sa #FOREACH_AST_FUNC_PARAM()
  * @sa #FOREACH_AST_FUNC_PARAM_UNTIL()
  */
-C_AST_H_INLINE NODISCARD
+NODISCARD C_AST_H_INLINE
 c_param_t const* c_ast_params( c_ast_t const *ast ) {
   return ast->as.func.param_ast_list.head;
 }
@@ -582,7 +582,7 @@ c_param_t const* c_ast_params( c_ast_t const *ast ) {
  * @sa #FOREACH_AST_FUNC_PARAM()
  * @sa #FOREACH_AST_FUNC_PARAM_UNTIL()
  */
-C_AST_H_INLINE NODISCARD
+NODISCARD C_AST_H_INLINE
 size_t c_ast_params_count( c_ast_t const *ast ) {
   return slist_len( &ast->as.func.param_ast_list );
 }
@@ -624,7 +624,7 @@ c_ast_t* c_ast_visit( c_ast_t *ast, c_visit_dir_t dir,
  * @sa #FOREACH_AST_FUNC_PARAM()
  * @sa #FOREACH_AST_FUNC_PARAM_UNTIL()
  */
-C_AST_H_INLINE NODISCARD
+NODISCARD C_AST_H_INLINE
 c_ast_t const* c_param_ast( c_param_t const *param ) {
   return param != NULL ? param->data : NULL;
 }

--- a/src/c_ast_util.h
+++ b/src/c_ast_util.h
@@ -467,7 +467,7 @@ c_ast_t const* c_ast_untypedef_qual( c_ast_t const *ast, c_tid_t *qual_stids );
  *
  * @sa c_tid_is_size_t()
  */
-C_AST_UTIL_H_INLINE NODISCARD
+NODISCARD C_AST_UTIL_H_INLINE
 bool c_ast_is_size_t( c_ast_t const *ast ) {
   return c_tid_is_size_t( c_ast_untypedef( ast )->type.btids );
 }
@@ -485,7 +485,7 @@ bool c_ast_is_size_t( c_ast_t const *ast ) {
  * @sa c_ast_is_ref_to_tid_any()
  * @sa c_ast_is_tid_any_qual()
  */
-C_AST_UTIL_H_INLINE NODISCARD
+NODISCARD C_AST_UTIL_H_INLINE
 c_ast_t const* c_ast_is_tid_any( c_ast_t const *ast, c_tid_t tids ) {
   c_tid_t qual_stids;
   return c_ast_is_tid_any_qual( ast, tids, &qual_stids );
@@ -498,7 +498,7 @@ c_ast_t const* c_ast_is_tid_any( c_ast_t const *ast, c_tid_t tids ) {
  * @param kind The kind to check for.
  * @return Returns `true` only if the parent of \a ast is \a kind.
  */
-C_AST_UTIL_H_INLINE NODISCARD
+NODISCARD C_AST_UTIL_H_INLINE
 bool c_ast_parent_is_kind( c_ast_t const *ast, c_ast_kind_t kind ) {
   return ast->parent_ast != NULL && ast->parent_ast->kind == kind;
 }
@@ -510,7 +510,7 @@ bool c_ast_parent_is_kind( c_ast_t const *ast, c_ast_kind_t kind ) {
  * @return Returns `true` only if \a ast should be printed as a `using`
  * declaration.
  */
-C_AST_UTIL_H_INLINE NODISCARD
+NODISCARD C_AST_UTIL_H_INLINE
 bool c_ast_print_as_using( c_ast_t const *ast ) {
   return  opt_using && OPT_LANG_IS( USING_DECLARATION ) &&
           c_tid_is_any( ast->type.stids, TS_TYPEDEF );

--- a/src/c_lang.h
+++ b/src/c_lang.h
@@ -805,7 +805,7 @@ struct c_lang_lit {
  * @sa c_lang_newer()
  * @sa c_lang_newest()
  */
-C_LANG_H_INLINE NODISCARD
+NODISCARD C_LANG_H_INLINE
 c_lang_id_t c_lang_and_newer( c_lang_id_t lang_id ) {
   lang_id &= ~LANGX_MASK;
   assert( is_1_bit( lang_id ) );
@@ -846,7 +846,7 @@ c_lang_id_t c_lang_find( char const *name );
  * @sa c_lang_is_cpp()
  * @sa c_lang_is_one()
  */
-C_LANG_H_INLINE NODISCARD
+NODISCARD C_LANG_H_INLINE
 bool c_lang_is_c( c_lang_id_t lang_ids ) {
   return (lang_ids & LANG_MASK_C) != LANG_NONE;
 }
@@ -860,7 +860,7 @@ bool c_lang_is_c( c_lang_id_t lang_ids ) {
  * @sa c_lang_is_c()
  * @sa c_lang_is_one()
  */
-C_LANG_H_INLINE NODISCARD
+NODISCARD C_LANG_H_INLINE
 bool c_lang_is_cpp( c_lang_id_t lang_ids ) {
   return (lang_ids & LANG_MASK_CPP) != LANG_NONE;
 }
@@ -920,7 +920,7 @@ char const* c_lang_name( c_lang_id_t lang_id );
  * @sa c_lang_newest()
  * @sa c_lang_oldest()
  */
-C_LANG_H_INLINE NODISCARD
+NODISCARD C_LANG_H_INLINE
 c_lang_id_t c_lang_newer( c_lang_id_t lang_id ) {
   lang_id &= ~LANGX_MASK;
   assert( is_1_bit( lang_id ) );
@@ -937,7 +937,7 @@ c_lang_id_t c_lang_newer( c_lang_id_t lang_id ) {
  * @sa c_lang_newer()
  * @sa c_lang_oldest()
  */
-C_LANG_H_INLINE NODISCARD
+NODISCARD C_LANG_H_INLINE
 c_lang_id_t c_lang_newest( c_lang_id_t lang_ids ) {
   return ms_bit1_32( lang_ids & ~LANGX_MASK ) | (lang_ids & LANGX_MASK);
 }
@@ -964,7 +964,7 @@ c_lang_t const* c_lang_next( c_lang_t const *lang );
  * @sa c_lang_newer()
  * @sa c_lang_newest()
  */
-C_LANG_H_INLINE NODISCARD
+NODISCARD C_LANG_H_INLINE
 c_lang_id_t c_lang_oldest( c_lang_id_t lang_ids ) {
   return ls_bit1_32( lang_ids & ~LANGX_MASK ) | (lang_ids & LANGX_MASK);
 }
@@ -1027,7 +1027,7 @@ char const* c_lang_which( c_lang_id_t lang_ids );
  *
  * @sa #OPT_LANG_IS()
  */
-C_LANG_H_INLINE NODISCARD
+NODISCARD C_LANG_H_INLINE
 bool opt_lang_is_any( c_lang_id_t lang_ids ) {
   return (opt_lang & lang_ids) != LANG_NONE;
 }

--- a/src/c_operator.h
+++ b/src/c_operator.h
@@ -239,7 +239,7 @@ c_operator_t const* c_oper_get( c_oper_id_t oper_id );
  * @param op The C++ operator to check.
  * @return Returns `true` only if the operator is ambiguous.
  */
-C_OPERATOR_H_INLINE NODISCARD
+NODISCARD C_OPERATOR_H_INLINE
 bool c_oper_is_ambiguous( c_operator_t const *op ) {
   return op->params_min == 0 && op->params_max == 2;
 }

--- a/src/c_sglob.h
+++ b/src/c_sglob.h
@@ -87,7 +87,7 @@ void c_sglob_cleanup( c_sglob_t *sglob );
  * @param sglob The scoped glob to check.
  * @return Returns `true` only if \a sglob is empty.
  */
-C_SGLOB_H_INLINE NODISCARD
+NODISCARD C_SGLOB_H_INLINE
 bool c_sglob_empty( c_sglob_t const *sglob ) {
   return sglob->count == 0;
 }

--- a/src/c_sname.h
+++ b/src/c_sname.h
@@ -213,7 +213,7 @@ void c_sname_cleanup( c_sname_t *sname );
  * @return Returns a number less than 0, 0, or greater than 0 if \a i_sname is
  * less than, equal to, or greater than \a j_sname, respectively.
  */
-C_SNAME_H_INLINE NODISCARD
+NODISCARD C_SNAME_H_INLINE
 int c_sname_cmp( c_sname_t const *i_sname, c_sname_t const *j_sname ) {
   return slist_cmp( i_sname, j_sname, (slist_cmp_fn_t)&c_scope_data_cmp );
 }
@@ -227,7 +227,7 @@ int c_sname_cmp( c_sname_t const *i_sname, c_sname_t const *j_sname ) {
  * @note This is named "count" rather than "len" to avoid misinterpretation
  * that "len" would be the total length of the strings and `::` separators.
  */
-C_SNAME_H_INLINE NODISCARD
+NODISCARD C_SNAME_H_INLINE
 size_t c_sname_count( c_sname_t const *sname ) {
   return slist_len( sname );
 }
@@ -239,7 +239,7 @@ size_t c_sname_count( c_sname_t const *sname ) {
  * @param sname The scoped name to duplicate.
  * @return Returns a duplicate of \a sname.
  */
-C_SNAME_H_INLINE NODISCARD
+NODISCARD C_SNAME_H_INLINE
 c_sname_t c_sname_dup( c_sname_t const *sname ) {
   return slist_dup( sname, -1, (slist_dup_fn_t)&c_scope_data_dup );
 }
@@ -250,7 +250,7 @@ c_sname_t c_sname_dup( c_sname_t const *sname ) {
  * @param sname The scoped name to check.
  * @return Returns `true` only if \a sname is empty.
  */
-C_SNAME_H_INLINE NODISCARD
+NODISCARD C_SNAME_H_INLINE
 bool c_sname_empty( c_sname_t const *sname ) {
   return slist_empty( sname );
 }
@@ -365,7 +365,7 @@ void c_sname_list_cleanup( slist_t *list );
  * @sa c_sname_name_atr()
  * @sa c_sname_scope_name()
  */
-C_SNAME_H_INLINE NODISCARD
+NODISCARD C_SNAME_H_INLINE
 char const* c_sname_local_name( c_sname_t const *sname ) {
   if ( sname == NULL )
     return "";
@@ -384,7 +384,7 @@ char const* c_sname_local_name( c_sname_t const *sname ) {
  * @sa c_sname_scope_type()
  * @sa c_sname_set_first_type()
  */
-C_SNAME_H_INLINE NODISCARD
+NODISCARD C_SNAME_H_INLINE
 c_type_t const* c_sname_first_type( c_sname_t const *sname ) {
   return c_sname_empty( sname ) ? &T_NONE : &c_scope_data( sname->head )->type;
 }
@@ -400,7 +400,7 @@ c_type_t const* c_sname_first_type( c_sname_t const *sname ) {
  * @sa c_sname_scope_type()
  * @sa c_sname_set_local_type()
  */
-C_SNAME_H_INLINE NODISCARD
+NODISCARD C_SNAME_H_INLINE
 c_type_t const* c_sname_local_type( c_sname_t const *sname ) {
   return c_sname_empty( sname ) ? &T_NONE : &c_scope_data( sname->tail )->type;
 }
@@ -441,7 +441,7 @@ bool c_sname_match( c_sname_t const *sname, c_sglob_t const *sglob );
  * @sa c_sname_full_name()
  * @sa c_sname_scope_name()
  */
-C_SNAME_H_INLINE NODISCARD
+NODISCARD C_SNAME_H_INLINE
 char const* c_sname_name_atr( c_sname_t const *sname, size_t roffset ) {
   c_scope_data_t const *const data = slist_atr( sname, roffset );
   return data != NULL ? data->name : "";
@@ -516,7 +516,7 @@ char const* c_sname_scope_name( c_sname_t const *sname );
  * @sa c_sname_local_type()
  * @sa c_sname_set_scope_type()
  */
-C_SNAME_H_INLINE NODISCARD
+NODISCARD C_SNAME_H_INLINE
 c_type_t const* c_sname_scope_type( c_sname_t const *sname ) {
   c_scope_data_t const *const data = slist_atr( sname, 1 );
   return data != NULL ? &data->type : &T_NONE;

--- a/src/c_type.h
+++ b/src/c_type.h
@@ -893,7 +893,7 @@ c_tid_t c_tid_check( c_tid_t tids, c_tpid_t tpid ) {
  *
  * @sa c_tid_compl()
  */
-C_TYPE_H_INLINE NODISCARD
+NODISCARD C_TYPE_H_INLINE
 bool c_tid_is_compl( c_tid_t tids ) {
   //
   // The low-order 4 bits specify the c_tpid.  Currently, type part IDs are 1
@@ -913,7 +913,7 @@ bool c_tid_is_compl( c_tid_t tids ) {
  *
  * @sa c_tid_is_compl()
  */
-C_TYPE_H_INLINE NODISCARD
+NODISCARD C_TYPE_H_INLINE
 c_tid_t c_tid_compl( c_tid_t tids ) {
   assert( !c_tid_is_compl( tids ) );
   return ~tids ^ TX_MASK_TPID;
@@ -929,7 +929,7 @@ c_tid_t c_tid_compl( c_tid_t tids ) {
  * @return Returns `true` only if \a tids contains any of \a is_tids, but not
  * any of \a except_tids.
  */
-C_TYPE_H_INLINE NODISCARD
+NODISCARD C_TYPE_H_INLINE
 bool c_tid_is_except( c_tid_t tids, c_tid_t is_tids, c_tid_t except_tids ) {
   return (tids & (is_tids | except_tids)) == is_tids;
 }
@@ -942,7 +942,7 @@ bool c_tid_is_except( c_tid_t tids, c_tid_t is_tids, c_tid_t except_tids ) {
  *
  * @sa c_tid_tpid()
  */
-C_TYPE_H_INLINE NODISCARD
+NODISCARD C_TYPE_H_INLINE
 c_tid_t c_tid_no_tpid( c_tid_t tids ) {
   return tids & ~TX_MASK_TPID;
 }
@@ -956,7 +956,7 @@ c_tid_t c_tid_no_tpid( c_tid_t tids ) {
  *
  * @sa c_type_is_any()
  */
-C_TYPE_H_INLINE NODISCARD
+NODISCARD C_TYPE_H_INLINE
 bool c_tid_is_any( c_tid_t i_tids, c_tid_t j_tids ) {
   assert( c_tid_tpid( i_tids ) == c_tid_tpid( j_tids ) );
   return c_tid_no_tpid( i_tids & j_tids ) != TX_NONE;
@@ -973,7 +973,7 @@ bool c_tid_is_any( c_tid_t i_tids, c_tid_t j_tids ) {
  *
  * @sa c_type_is_none()
  */
-C_TYPE_H_INLINE NODISCARD
+NODISCARD C_TYPE_H_INLINE
 bool c_tid_is_none( c_tid_t tids ) {
   return c_tid_no_tpid( tids ) == TX_NONE;
 }
@@ -989,7 +989,7 @@ bool c_tid_is_none( c_tid_t tids ) {
  *
  * @sa c_ast_is_size_t()
  */
-C_TYPE_H_INLINE NODISCARD
+NODISCARD C_TYPE_H_INLINE
 bool c_tid_is_size_t( c_tid_t tids ) {
   c_tid_check( tids, C_TPID_BASE );
   return (tids & c_tid_compl( TB_INT )) == (TB_UNSIGNED | TB_LONG);
@@ -1003,7 +1003,7 @@ bool c_tid_is_size_t( c_tid_t tids ) {
  *
  * @sa c_type_equiv()
  */
-C_TYPE_H_INLINE NODISCARD
+NODISCARD C_TYPE_H_INLINE
 bool c_type_is_none( c_type_t const *type ) {
   return c_type_equiv( type, &T_NONE );
 }

--- a/src/literals.h
+++ b/src/literals.h
@@ -376,7 +376,7 @@ extern char const L_MSC_WINAPI[];         // synonym for "__stdcall"
  *
  * @return Returns either `_Alignas` (for C) or `alignas` (for C++).
  */
-C_LITERALS_H_INLINE NODISCARD
+NODISCARD C_LITERALS_H_INLINE
 char const* alignas_name( void ) {
   return OPT_LANG_IS( C_ANY ) ? L__ALIGNAS : L_ALIGNAS;
 }

--- a/src/red_black.h
+++ b/src/red_black.h
@@ -243,7 +243,7 @@ void* rb_tree_delete( rb_tree_t *tree, rb_node_t *node );
  * @param tree A pointer to the red-black tree to check.
  * @return Returns `true` only if \a tree is empty.
  */
-RED_BLACK_H_INLINE NODISCARD
+NODISCARD RED_BLACK_H_INLINE
 bool rb_tree_empty( rb_tree_t const *tree ) {
   return tree->fake_root.child[0] == &tree->nil;
 }

--- a/src/slist.h
+++ b/src/slist.h
@@ -303,7 +303,7 @@ void slist_push_list_front( slist_t *dst_list, slist_t *src_list );
  * @sa slist_back()
  * @sa slist_front()
  */
-SLIST_H_INLINE NODISCARD
+NODISCARD SLIST_H_INLINE
 void* slist_at( slist_t const *list, size_t offset ) {
   return offset < list->len ? slist_at_nocheck_offset( list, offset ) : NULL;
 }
@@ -322,7 +322,7 @@ void* slist_at( slist_t const *list, size_t offset ) {
  * @sa slist_back()
  * @sa slist_front()
  */
-SLIST_H_INLINE NODISCARD
+NODISCARD SLIST_H_INLINE
 void* slist_atr( slist_t const *list, size_t roffset ) {
   return roffset < list->len ?
     slist_at_nocheck_offset( list, list->len - (roffset + 1) ) : NULL;
@@ -341,7 +341,7 @@ void* slist_atr( slist_t const *list, size_t roffset ) {
  * @sa slist_atr()
  * @sa slist_front()
  */
-SLIST_H_INLINE NODISCARD
+NODISCARD SLIST_H_INLINE
 void* slist_back( slist_t const *list ) {
   return list->tail != NULL ? list->tail->data : NULL;
 }
@@ -356,7 +356,7 @@ void* slist_back( slist_t const *list ) {
  *
  * @sa slist_len()
  */
-SLIST_H_INLINE NODISCARD
+NODISCARD SLIST_H_INLINE
 bool slist_empty( slist_t const *list ) {
   return list->head == NULL;
 }
@@ -374,7 +374,7 @@ bool slist_empty( slist_t const *list ) {
  * @sa slist_atr()
  * @sa slist_back()
  */
-SLIST_H_INLINE NODISCARD
+NODISCARD SLIST_H_INLINE
 void* slist_front( slist_t const *list ) {
   return list->head != NULL ? list->head->data : NULL;
 }
@@ -402,7 +402,7 @@ void slist_init( slist_t *list ) {
  *
  * @sa slist_empty()
  */
-SLIST_H_INLINE NODISCARD
+NODISCARD SLIST_H_INLINE
 size_t slist_len( slist_t const *list ) {
   return list->len;
 }

--- a/src/strbuf.h
+++ b/src/strbuf.h
@@ -308,7 +308,7 @@ void strbuf_sepc_puts( strbuf_t *sbuf, char sep, bool *sep_flag,
  * @sa strbuf_init()
  * @sa strbuf_reset()
  */
-STRBUF_H_INLINE NODISCARD
+NODISCARD STRBUF_H_INLINE
 char* strbuf_take( strbuf_t *sbuf ) {
   char *const str = sbuf->str;
   strbuf_init( sbuf );

--- a/src/util.h
+++ b/src/util.h
@@ -655,7 +655,7 @@ char* check_strndup( char const *s, size_t n );
  * @sa true_clear()
  * @sa true_or_set()
  */
-C_UTIL_H_INLINE NODISCARD
+NODISCARD C_UTIL_H_INLINE
 bool false_set( bool *flag ) {
   return !*flag && (*flag = true);
 }
@@ -775,7 +775,7 @@ char const* home_dir( void );
  * @sa is_1_bit_only_in_set()
  * @sa is_1n_bit_only_in_set()
  */
-C_UTIL_H_INLINE NODISCARD
+NODISCARD C_UTIL_H_INLINE
 bool is_01_bit( uint64_t n ) {
   return (n & (n - 1)) == 0;
 }
@@ -796,7 +796,7 @@ bool is_01_bit( uint64_t n ) {
  * @sa is_1_bit_only_in_set()
  * @sa is_1n_bit_only_in_set()
  */
-C_UTIL_H_INLINE NODISCARD
+NODISCARD C_UTIL_H_INLINE
 bool is_0n_bit_only_in_set( uint64_t n, uint64_t set ) {
   return (n & set) == n;
 }
@@ -814,7 +814,7 @@ bool is_0n_bit_only_in_set( uint64_t n, uint64_t set ) {
  * @sa is_1_bit_only_in_set()
  * @sa is_1n_bit_only_in_set()
  */
-C_UTIL_H_INLINE NODISCARD
+NODISCARD C_UTIL_H_INLINE
 bool is_1_bit( uint64_t n ) {
   return n != 0 && is_01_bit( n );
 }
@@ -835,7 +835,7 @@ bool is_1_bit( uint64_t n ) {
  * @sa is_1_bit_only_in_set()
  * @sa is_1n_bit_only_in_set()
  */
-C_UTIL_H_INLINE NODISCARD
+NODISCARD C_UTIL_H_INLINE
 bool is_1_bit_in_set( uint64_t n, uint64_t set ) {
   return is_1_bit( n & set );
 }
@@ -854,7 +854,7 @@ bool is_1_bit_in_set( uint64_t n, uint64_t set ) {
  * @sa is_1_bit_in_set()
  * @sa is_1n_bit_only_in_set()
  */
-C_UTIL_H_INLINE NODISCARD
+NODISCARD C_UTIL_H_INLINE
 bool is_1_bit_only_in_set( uint64_t n, uint64_t set ) {
   return is_1_bit( n ) && (n & set) != 0;
 }
@@ -874,7 +874,7 @@ bool is_1_bit_only_in_set( uint64_t n, uint64_t set ) {
  * @sa is_1_bit_only_in_set()
  * @sa is_1n_bit_only_in_set()
  */
-C_UTIL_H_INLINE NODISCARD
+NODISCARD C_UTIL_H_INLINE
 bool is_01_bit_only_in_set( uint64_t n, uint64_t set ) {
   return n == 0 || is_1_bit_only_in_set( n, set );
 }
@@ -895,7 +895,7 @@ bool is_01_bit_only_in_set( uint64_t n, uint64_t set ) {
  * @sa is_1_bit_in_set()
  * @sa is_1_bit_only_in_set()
  */
-C_UTIL_H_INLINE NODISCARD
+NODISCARD C_UTIL_H_INLINE
 bool is_1n_bit_only_in_set( uint64_t n, uint64_t set ) {
   return n != 0 && is_0n_bit_only_in_set( n, set );
 }
@@ -907,7 +907,7 @@ bool is_1n_bit_only_in_set( uint64_t n, uint64_t set ) {
  * @return Returns `true` only if \a c is either an alphanumeric or `_`
  * character.
  */
-C_UTIL_H_INLINE NODISCARD
+NODISCARD C_UTIL_H_INLINE
 bool is_ident( char c ) {
   return isalnum( c ) || c == '_';
 }
@@ -984,7 +984,7 @@ void perror_exit_if( bool expr, int status ) {
  *
  * @sa null_if_empty()
  */
-C_UTIL_H_INLINE NODISCARD
+NODISCARD C_UTIL_H_INLINE
 bool str_is_empty( char const *s ) {
   SKIP_WS( s );
   return *s == '\0';
@@ -1000,7 +1000,7 @@ bool str_is_empty( char const *s ) {
  *
  * @sa str_is_empty()
  */
-C_UTIL_H_INLINE NODISCARD
+NODISCARD C_UTIL_H_INLINE
 char const* null_if_empty( char const *s ) {
   return s != NULL && str_is_empty( s ) ? NULL : s;
 }
@@ -1045,7 +1045,7 @@ void str_rtrim_len( char const *s, size_t *s_len );
  * @sa false_set()
  * @sa true_clear()
  */
-C_UTIL_H_INLINE NODISCARD
+NODISCARD C_UTIL_H_INLINE
 bool true_or_set( bool *flag ) {
   return *flag || !(*flag = true);
 }
@@ -1060,7 +1060,7 @@ bool true_or_set( bool *flag ) {
  * @sa false_set()
  * @sa true_or_set()
  */
-C_UTIL_H_INLINE NODISCARD
+NODISCARD C_UTIL_H_INLINE
 bool true_clear( bool *flag ) {
   return *flag && !(*flag = false);
 }


### PR DESCRIPTION
```
gcc [...] 
In file included from c_ast.h:35,
                 from parser.y:36:
c_operator.h:243:1: warning: 'nodiscard' attribute ignored [-Wattributes]
  243 | bool c_oper_is_ambiguous( c_operator_t const *op ) {
In file included from c_operator.h:36:
c_operator.h:243:1: error: expected identifier or '(' before '_Bool'
  243 | bool c_oper_is_ambiguous( c_operator_t const *op ) {
```

As per https://en.cppreference.com/w/c/language/declarations ,
C2X attributes must precede specifiers like "inline".

Fixes: #22