### PR TITLE
autocomplete: add L_by to L_reference next-keyword list

### DIFF
--- a/src/cdecl_keyword.c
+++ b/src/cdecl_keyword.c
@@ -1428,7 +1428,7 @@ static cdecl_keyword_t CDECL_KEYWORDS[] = {
     AC_SETTINGS(
       LANG_CPP_ANY,
       AC_POLICY_NONE,
-      AC_NEXT_KEYWORDS( L_to )
+      AC_NEXT_KEYWORDS( L_by, L_to )
     )
   },
 


### PR DESCRIPTION
Ultimate target:

	c++decl> declare lambda capturing [reference by default]
	[&]

User input:

	c++decl> declare lambda capturing [reference <TAB>

Result set of Tab Completion:

* {"to"}

Expected result set:

* {"by", "to"}